### PR TITLE
Fix default tag bump to patch

### DIFF
--- a/.github/workflows/auto-tagger.yml
+++ b/.github/workflows/auto-tagger.yml
@@ -22,3 +22,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
           WITH_V: true
           RELEASE_BRANCHES: main
+          DEFAULT_BUMP: patch


### PR DESCRIPTION
- **b4 1**
- **b4 2**
- **b4 3**
- **b4 3 #patch**
- **b4 4 #patch**
- **checking the git messages**
- **checking the git messages #skip**
- **checking the git messages #skip second**
- **checking the git messages #skip second 1**
- **checking the git messages #skip second 1**
- **add CI pipeline for building, testing and auto tag generation**
- **fix: CI pipeline for auto tag generation**
- **fix: add default tag bumper to patch**
